### PR TITLE
Governance: apply Botshare LTD IP, licence, and contribution baseline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+# Pull request
+
+Describe the change, scope, validation, compatibility, migration, and safety impact.
+
+## Intellectual property and provenance
+
+- [ ] Every commit is signed off under the OpenAMRobot DCO.
+- [ ] I am covered by an accepted Individual or Corporate Contributor Agreement.
+- [ ] I have all required employer, university, client, sponsor, co-author, or institutional authorization.
+- [ ] Third-party and material AI-assisted content is identified with source, licence, modifications, and notices.
+- [ ] No unauthorized confidential, personal, proprietary, credential, or export-controlled information is included.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Follow the repository's technical guidance and the organization [Contribution Guide](https://github.com/openAMRobot/.github/blob/main/CONTRIBUTING.md).
+
+## Legal requirements
+
+Before acceptance, every commit must satisfy the DCO and the contributor must be covered by an applicable Individual or Corporate Contributor Agreement. Obtain any required employer, university, client, sponsor, co-author, or institutional authorization. Disclose third-party and material AI-assisted content with source, licence, modifications, and notices. Do not submit unauthorized confidential, personal, proprietary, credential, or export-controlled information.
+
+The Contributor Agreement governs assignment of transferable economic rights in accepted contributions to **Botshare LTD**. DCO confirms provenance and authority but does not replace that agreement.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,17 @@
+# Release Licensing Policy
+
+This repository aggregates versioned OpenAMRobot components. It does not apply one blanket licence to the complete release.
+
+Every release must identify, for each included component:
+
+- source repository and immutable commit or tag;
+- asset type and authoritative path;
+- copyright owner;
+- applicable outbound licence;
+- third-party dependencies and notices;
+- modifications and build provenance;
+- checksum or digest.
+
+Typical licences include MIT for original software, Apache-2.0 for identified upstream derivatives, an expressly selected hardware licence for hardware design source, and an expressly stated documentation licence. Logos and official branding are not licensed by component software/hardware licences.
+
+OpenAMRobot is operated by **Botshare LTD**. Botshare LTD owns original or validly assigned OpenAMRobot rights; third-party rights remain unaffected. See https://github.com/openAMRobot/.github/blob/main/IP_POLICY.md.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,7 @@
+# Notice
+
+OpenAMRobot is a project initiated, operated, and controlled by **Botshare LTD**, Company ID HE479056, Chrysanthou Mylona 1, Panayides Building, Office 1, 3030 Limassol, Cyprus (alex@botshare.ai; https://botshare.ai).
+
+Copyright and transferable economic rights in original OpenAMRobot material are owned by Botshare LTD or used by it under applicable agreements. Accepted external contributions are governed by the OpenAMRobot Contributor Agreement.
+
+Botshare LTD does not claim ownership of third-party material. Authentic upstream ownership, licence, patent, attribution, and modification notices remain effective.

--- a/README.md
+++ b/README.md
@@ -171,3 +171,11 @@ If you find this project useful, please consider supporting its development.
 - GitHub Sponsors: https://github.com/sponsors/openAMRobot
 
 Your support helps us improve the hardware, firmware, software, documentation, educational materials, and future releases.
+
+## Ownership, licensing, and contributions
+
+OpenAMRobot is a project initiated, operated, and controlled by **Botshare LTD** (Cyprus Company ID HE479056). Botshare LTD owns the transferable economic rights in original OpenAMRobot material created by or validly assigned to it. Third-party material remains subject to its respective ownership, licences, and notices.
+
+Public distribution under this repository's applicable licence grants the permissions stated in that licence; it does not transfer ownership of underlying copyright, trademarks, patents, or other intellectual property.
+
+Accepted external contributions require DCO sign-off and an applicable Individual or Corporate Contributor Agreement. See the organization [IP Policy](https://github.com/openAMRobot/.github/blob/main/IP_POLICY.md), [Contribution Guide](https://github.com/openAMRobot/.github/blob/main/CONTRIBUTING.md), and [Contributor Agreement Process](https://github.com/openAMRobot/.github/blob/main/CLA.md).


### PR DESCRIPTION
## Summary

Applies the organization IP and contribution baseline and replaces missing/empty licensing controls with an asset-appropriate policy.

- identifies Botshare LTD as project owner;
- requires DCO and an applicable Contributor Agreement;
- adds third-party and AI-assisted provenance controls;
- preserves authentic third-party rights and notices;
- establishes the repository licence or component-level release licensing policy.

Depends conceptually on openAMRobot/.github#26. One signed-off commit; no direct change to main.