### PR TITLE
legal: adopt asset-specific licensing and IP notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,20 +3,19 @@ MIT License
 Copyright (c) 2021-2026 OpenAMRobot (Botshare LTD)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software, documentation, hardware design source, and associated
-materials (the "Materials"), to deal in the Materials without restriction,
-including without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Materials, and to permit
-persons to whom the Materials are furnished to do so, subject to the following
-conditions:
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Materials.
+copies or substantial portions of the Software.
 
-THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS IN THE
-MATERIALS.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2021-2026 OpenAMRobot (Botshare LTD)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software, documentation, hardware design source, and associated
+materials (the "Materials"), to deal in the Materials without restriction,
+including without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to permit
+persons to whom the Materials are furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS IN THE
+MATERIALS.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,29 +1,27 @@
-# Licensing
+# OpenAMRobot licensing standard
 
-## Original OpenAMRobot material
+OpenAMRobot uses asset-appropriate permissive licences for original material owned by or validly assigned to **OpenAMRobot (Botshare LTD)**.
 
-Unless a file or directory expressly states otherwise, original material in this repository is made available under the [MIT License](LICENSE).
-
-This includes original software, firmware, documentation, diagrams, CAD and hardware design source, schematics, specifications, tests, examples, and other project material owned by or validly assigned to **OpenAMRobot (Botshare LTD)**.
+| Material | Licence |
+|---|---|
+| Software, firmware, scripts, configuration, APIs, tests, and code examples | [MIT](https://spdx.org/licenses/MIT.html) |
+| Documentation, diagrams, tutorials, original images, and other authored content | [Creative Commons Attribution 4.0 International](https://spdx.org/licenses/CC-BY-4.0.html) |
+| CAD, PCB and schematic source, mechanical/electrical design files, manufacturing source, and CAD-derived robot geometry | [CERN Open Hardware Licence Version 2 — Permissive](https://spdx.org/licenses/CERN-OHL-P-2.0.html) |
 
 Copyright (c) 2021–2026 OpenAMRobot (Botshare LTD).
 
-The MIT licence grants broad permissions to use, copy, modify, manufacture from, distribute, sublicense, and sell the licensed material. It does not transfer ownership of copyright, patents, trademarks, project identity, confidential information, or other underlying intellectual property.
+The root `LICENSE` identifies the predominant licence for this repository. Where a repository contains several asset types, the table above and any more specific file, directory, SPDX, package, or notice declaration determine the applicable licence.
 
 ## Third-party material
 
-The MIT licence in this repository does not relicense third-party material. Third-party material remains governed by its original owners, licences, notices, patent terms, attribution requirements, and source-offer obligations.
+No OpenAMRobot licence relicenses third-party material. Third-party material remains governed by its original ownership, licence, patent, attribution, modification, and source-availability terms. Specific third-party terms control over this general policy and are recorded in source headers, dependency manifests, `NOTICE.md`, `THIRD_PARTY_NOTICES.md`, accompanying licence files, or the material itself.
 
-Applicable third-party terms are identified in source headers, dependency manifests, `NOTICE.md`, `THIRD_PARTY_NOTICES.md`, accompanying licence files, or the material itself. Where there is a conflict, the specific third-party terms control for that material.
+## Ownership and branding
 
-## Branding
-
-OpenAMRobot, OpenAMR, associated logos, visual identity, certification statements, and official project branding are not granted under MIT. See the organization [Trademark Policy](https://github.com/openAMRobot/.github/blob/main/TRADEMARK_POLICY.md).
+Public licensing grants the permissions in the applicable licence; it does not transfer ownership of the underlying intellectual property. OpenAMRobot, OpenAMR, associated logos, visual identity, and claims of official affiliation or certification are not licensed under MIT, CC BY 4.0, or CERN-OHL-P-2.0. See the organization [Trademark Policy](https://github.com/openAMRobot/.github/blob/main/TRADEMARK_POLICY.md).
 
 ## Earlier distributions
 
-Licences validly granted for earlier copies remain effective for those copies. This repository's current default branch expresses the licensing policy for current and future distributions, subject to third-party rights and mandatory law.
-
-## Questions
+Licences validly granted for earlier copies remain effective for those copies. The current default branch states the policy for current and future distributions, subject to third-party rights and mandatory law.
 
 Licensing and provenance questions: **info@botshare.ai**.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -12,6 +12,18 @@ Copyright (c) 2021–2026 OpenAMRobot (Botshare LTD).
 
 The root `LICENSE` identifies the predominant licence for this repository. Where a repository contains several asset types, the table above and any more specific file, directory, SPDX, package, or notice declaration determine the applicable licence.
 
+## Release-package requirements
+
+Every published OpenAMRobot release archive must contain:
+
+- this licence map and the complete applicable licence texts;
+- the source repository, release tag or immutable commit for every included component;
+- third-party notices, attributions, licence texts, and source-availability information required by upstream terms;
+- checksums or another integrity record for distributed artifacts; and
+- a statement identifying any excluded proprietary, confidential, trademark, credential, or security-sensitive material.
+
+Release automation must fail rather than publish when required licence evidence or third-party notices are missing. A release manifest records provenance; it does not itself change any component's licence.
+
 ## Third-party material
 
 No OpenAMRobot licence relicenses third-party material. Third-party material remains governed by its original ownership, licence, patent, attribution, modification, and source-availability terms. Specific third-party terms control over this general policy and are recorded in source headers, dependency manifests, `NOTICE.md`, `THIRD_PARTY_NOTICES.md`, accompanying licence files, or the material itself.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,17 +1,29 @@
-# Release Licensing Policy
+# Licensing
 
-This repository aggregates versioned OpenAMRobot components. It does not apply one blanket licence to the complete release.
+## Original OpenAMRobot material
 
-Every release must identify, for each included component:
+Unless a file or directory expressly states otherwise, original material in this repository is made available under the [MIT License](LICENSE).
 
-- source repository and immutable commit or tag;
-- asset type and authoritative path;
-- copyright owner;
-- applicable outbound licence;
-- third-party dependencies and notices;
-- modifications and build provenance;
-- checksum or digest.
+This includes original software, firmware, documentation, diagrams, CAD and hardware design source, schematics, specifications, tests, examples, and other project material owned by or validly assigned to **OpenAMRobot (Botshare LTD)**.
 
-Typical licences include MIT for original software, Apache-2.0 for identified upstream derivatives, an expressly selected hardware licence for hardware design source, and an expressly stated documentation licence. Logos and official branding are not licensed by component software/hardware licences.
+Copyright (c) 2021–2026 OpenAMRobot (Botshare LTD).
 
-OpenAMRobot is operated by **Botshare LTD**. Botshare LTD owns original or validly assigned OpenAMRobot rights; third-party rights remain unaffected. See https://github.com/openAMRobot/.github/blob/main/IP_POLICY.md.
+The MIT licence grants broad permissions to use, copy, modify, manufacture from, distribute, sublicense, and sell the licensed material. It does not transfer ownership of copyright, patents, trademarks, project identity, confidential information, or other underlying intellectual property.
+
+## Third-party material
+
+The MIT licence in this repository does not relicense third-party material. Third-party material remains governed by its original owners, licences, notices, patent terms, attribution requirements, and source-offer obligations.
+
+Applicable third-party terms are identified in source headers, dependency manifests, `NOTICE.md`, `THIRD_PARTY_NOTICES.md`, accompanying licence files, or the material itself. Where there is a conflict, the specific third-party terms control for that material.
+
+## Branding
+
+OpenAMRobot, OpenAMR, associated logos, visual identity, certification statements, and official project branding are not granted under MIT. See the organization [Trademark Policy](https://github.com/openAMRobot/.github/blob/main/TRADEMARK_POLICY.md).
+
+## Earlier distributions
+
+Licences validly granted for earlier copies remain effective for those copies. This repository's current default branch expresses the licensing policy for current and future distributions, subject to third-party rights and mandatory law.
+
+## Questions
+
+Licensing and provenance questions: **info@botshare.ai**.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,6 +1,6 @@
 # Notice
 
-OpenAMRobot is a project initiated, operated, and controlled by **Botshare LTD**, Company ID HE479056, Chrysanthou Mylona 1, Panayides Building, Office 1, 3030 Limassol, Cyprus (alex@botshare.ai; https://botshare.ai).
+OpenAMRobot is a project initiated, operated, and controlled by **Botshare LTD**, Company ID HE479056, Chrysanthou Mylona 1, Panayides Building, Office 1, 3030 Limassol, Cyprus (info@botshare.ai; https://botshare.ai).
 
 Copyright and transferable economic rights in original OpenAMRobot material are owned by Botshare LTD or used by it under applicable agreements. Accepted external contributions are governed by the OpenAMRobot Contributor Agreement.
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,6 @@ Your support helps us improve the hardware, firmware, software, documentation, e
 
 OpenAMRobot is a project initiated, operated, and controlled by **Botshare LTD** (Cyprus Company ID HE479056). Botshare LTD owns the transferable economic rights in original OpenAMRobot material created by or validly assigned to it. Third-party material remains subject to its respective ownership, licences, and notices.
 
-Public distribution under this repository's applicable licence grants the permissions stated in that licence; it does not transfer ownership of underlying copyright, trademarks, patents, or other intellectual property.
+Original OpenAMRobot software and firmware are licensed under MIT, documentation under CC BY 4.0, and hardware design source under CERN-OHL-P-2.0, as mapped in [`LICENSING.md`](LICENSING.md). Public distribution grants the permissions stated in the applicable licence; it does not transfer ownership of underlying copyright, trademarks, patents, or other intellectual property.
 
 Accepted external contributions require DCO sign-off and an applicable Individual or Corporate Contributor Agreement. See the organization [IP Policy](https://github.com/openAMRobot/.github/blob/main/IP_POLICY.md), [Contribution Guide](https://github.com/openAMRobot/.github/blob/main/CONTRIBUTING.md), and [Contributor Agreement Process](https://github.com/openAMRobot/.github/blob/main/CLA.md).


### PR DESCRIPTION
## Summary

- adopts the OpenAMRobot asset-specific licensing standard:
  - MIT for software and firmware
  - CC BY 4.0 for documentation and original media
  - CERN-OHL-P-2.0 for hardware source, CAD, schematics, manufacturing source, and CAD-derived geometry
- identifies OpenAMRobot (Botshare LTD) consistently while preserving third-party rights
- standardizes licensing and provenance contact to info@botshare.ai
- explains that prior valid licence grants remain effective
- adds or updates repository-specific metadata and notices where applicable

## Safeguards

- no third-party material is relicensed
- trademarks and branding are excluded from the open-content grants
- mixed repositories use LICENSING.md plus more-specific file/directory notices
- DCO and CLA checks remain required by branch protection

## Review focus

Verify repository classification, third-party notices, asset provenance, and any file-specific exceptions before merge.

Signed-off-by: Alex Reznichenko <info@botshare.ai>